### PR TITLE
Misc fixes without a major API change

### DIFF
--- a/ip2location.c
+++ b/ip2location.c
@@ -587,6 +587,7 @@ PHP_FUNCTION(ip2location_get_all)
 	add_assoc_string(return_value, "mobilebrand",record->mobilebrand, 1 );
 	add_assoc_double(return_value, "elevation",record->elevation);
 	add_assoc_string(return_value, "usagetype",record->usagetype, 1 );
+	IP2Location_free_record(record);
 }
 /* }}} */
 


### PR DESCRIPTION
First of all, returning a string containing an error message in case of error is wrong, we have warnings and notices for that.
This is probably the most significant change here, the other ones being more about minor memleaks, copy/pasted code moved to a macro and coding standards.
