### PR TITLE
delete share memory object when process terminate

### DIFF
--- a/ip2location.c
+++ b/ip2location.c
@@ -138,6 +138,12 @@ PHP_MINIT_FUNCTION(ip2location)
  *  */
 PHP_MSHUTDOWN_FUNCTION(ip2location)
 {
+#if API_VERSION_NUMERIC >= 80100
+	IP2Location_clear_memory();
+#else
+	IP2Location_delete_shm();
+#endif
+
 	return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
Related to https://github.com/chrislim2888/IP2Location-C-Library/issues/42 and https://github.com/chrislim2888/IP2Location-C-Library/pull/43

If this fix proposal is accepted in the library, makes sense to delete this shared memory object when the process terminates, as won't be used anymore.