### PR TITLE
Add type hinting for PHP 8+

### DIFF
--- a/ip2location.c
+++ b/ip2location.c
@@ -26,13 +26,7 @@
 
 #if PHP_MAJOR_VERSION >= 8
 #include "ip2location_arginfo.h"
-
 #else
-/* For PHP < 5.3.7 */
-#ifndef PHP_FE_END
-#define PHP_FE_END {NULL, NULL, NULL}
-#endif
-
 #include "ip2location_legacy_arginfo.h"
 #endif
 

--- a/ip2location.c
+++ b/ip2location.c
@@ -24,6 +24,18 @@
 
 #include "php_ip2location.h"
 
+#if PHP_MAJOR_VERSION >= 8
+#include "ip2location_arginfo.h"
+
+#else
+/* For PHP < 5.3.7 */
+#ifndef PHP_FE_END
+#define PHP_FE_END {NULL, NULL, NULL}
+#endif
+
+#include "ip2location_legacy_arginfo.h"
+#endif
+
 /* For PHP 8 */
 #ifndef TSRMLS_CC
 #define TSRMLS_CC
@@ -33,71 +45,11 @@ ZEND_DECLARE_MODULE_GLOBALS(ip2location)
 
 #define IP2LOCATION_RECORD 0
 
-ZEND_BEGIN_ARG_INFO_EX(ip2location_open, 0, 0, 1)
-	ZEND_ARG_INFO(0, file_path)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(ip2location_open_mem, 0, 0, 1)
-	ZEND_ARG_INFO(0, method)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(ip2location_ip_address, 0, 0, 1)
-	ZEND_ARG_INFO(0, ip_address)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(ip2location_void, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-static zend_function_entry ip2location_functions_entry[] = {
-	PHP_FE(ip2location_open, ip2location_open)
-	PHP_FE(ip2location_open_mem, ip2location_open_mem)
-	PHP_FE(ip2location_get_country_short, ip2location_ip_address)
-	PHP_FE(ip2location_get_country_long, ip2location_ip_address)
-	PHP_FE(ip2location_get_region, ip2location_ip_address)
-	PHP_FE(ip2location_get_city, ip2location_ip_address)
-	PHP_FE(ip2location_get_isp, ip2location_ip_address)
-	PHP_FE(ip2location_get_latitude, ip2location_ip_address)
-	PHP_FE(ip2location_get_longitude, ip2location_ip_address)
-	PHP_FE(ip2location_get_domain, ip2location_ip_address)
-	PHP_FE(ip2location_get_zipcode, ip2location_ip_address)
-	PHP_FE(ip2location_get_timezone, ip2location_ip_address)
-	PHP_FE(ip2location_get_netspeed, ip2location_ip_address)
-	PHP_FE(ip2location_get_iddcode, ip2location_ip_address)
-	PHP_FE(ip2location_get_areacode, ip2location_ip_address)
-	PHP_FE(ip2location_get_weatherstationcode, ip2location_ip_address)
-	PHP_FE(ip2location_get_weatherstationname, ip2location_ip_address)
-	PHP_FE(ip2location_get_mcc, ip2location_ip_address)
-	PHP_FE(ip2location_get_mnc, ip2location_ip_address)
-	PHP_FE(ip2location_get_mobilebrand, ip2location_ip_address)
-	PHP_FE(ip2location_get_elevation, ip2location_ip_address)
-	PHP_FE(ip2location_get_usagetype, ip2location_ip_address)
-	PHP_FE(ip2location_get_all, ip2location_ip_address)
-	PHP_FE(ip2location_close, ip2location_void)
-	PHP_FE(ip2location_delete_shm, ip2location_void)
-#if API_VERSION_NUMERIC >= 80300
-	PHP_FE(ip2location_bin_version, ip2location_void)
-#endif
-#if API_VERSION_NUMERIC >= 80400
-	PHP_FE(ip2location_get_addresstype, ip2location_ip_address)
-	PHP_FE(ip2location_get_category, ip2location_ip_address)
-#endif
-#if API_VERSION_NUMERIC >= 80600
-	PHP_FE(ip2location_get_district, ip2location_ip_address)
-	PHP_FE(ip2location_get_asn, ip2location_ip_address)
-	PHP_FE(ip2location_get_as, ip2location_ip_address)
-#endif
-#ifdef PHP_FE_END
-	PHP_FE_END
-#else
-	{NULL, NULL, NULL}
-#endif
-};
-
 /* the following code creates an entry for the module and registers it with Zend.*/
 zend_module_entry ip2location_module_entry = {
 	STANDARD_MODULE_HEADER,
 	PHP_IP2LOCATION_EXTNAME,
-	ip2location_functions_entry,
+	ext_functions,
 	PHP_MINIT(ip2location),
 	PHP_MSHUTDOWN(ip2location),
 	NULL, 

--- a/ip2location.stub.php
+++ b/ip2location.stub.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+function ip2location_open(string $file_path): bool {}
+function ip2location_open_mem(int $method): bool {}
+function ip2location_get_country_short(string $ip_address): string {}
+function ip2location_get_country_long(string $ip_address): string {}
+function ip2location_get_region(string $ip_address): string {}
+function ip2location_get_city(string $ip_address): string {}
+function ip2location_get_isp(string $ip_address): string {}
+function ip2location_get_latitude(string $ip_address): string {}
+function ip2location_get_longitude(string $ip_address): string {}
+function ip2location_get_domain(string $ip_address): string {}
+function ip2location_get_zipcode(string $ip_address): string {}
+function ip2location_get_timezone(string $ip_address): string {}
+function ip2location_get_netspeed(string $ip_address): string {}
+function ip2location_get_iddcode(string $ip_address): string {}
+function ip2location_get_areacode(string $ip_address): string {}
+function ip2location_get_weatherstationcode(string $ip_address): string {}
+function ip2location_get_weatherstationname(string $ip_address): string {}
+function ip2location_get_mcc(string $ip_address): string {}
+function ip2location_get_mnc(string $ip_address): string {}
+function ip2location_get_mobilebrand(string $ip_address): string {}
+function ip2location_get_elevation(string $ip_address): string {}
+function ip2location_get_usagetype(string $ip_address): string {}
+function ip2location_get_all(string $ip_address): array {}
+function ip2location_close(): void {}
+function ip2location_delete_shm(): void {}
+#if API_VERSION_NUMERIC >= 80300
+function ip2location_bin_version(): string {}
+#endif
+#if API_VERSION_NUMERIC >= 80400
+function ip2location_get_addresstype(string $ip_address): string {}
+function ip2location_get_category(string $ip_address): string {}
+#endif
+#if API_VERSION_NUMERIC >= 80600
+function ip2location_get_district(string $ip_address): string {}
+function ip2location_get_asn(string $ip_address): string {}
+function ip2location_get_as(string $ip_address): string {}
+#endif
+

--- a/ip2location_arginfo.h
+++ b/ip2location_arginfo.h
@@ -1,0 +1,183 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: c57e18a606ee629525559e7f245e9643c54c59c5 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_open, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, file_path, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_open_mem, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_get_country_short, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, ip_address, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ip2location_get_country_long arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_region arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_city arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_isp arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_latitude arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_longitude arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_domain arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_zipcode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_timezone arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_netspeed arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_iddcode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_areacode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_weatherstationcode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_weatherstationname arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_mcc arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_mnc arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_mobilebrand arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_elevation arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_usagetype arginfo_ip2location_get_country_short
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_get_all, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, ip_address, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_close, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ip2location_delete_shm arginfo_ip2location_close
+
+#if API_VERSION_NUMERIC >= 80300
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_bin_version, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if API_VERSION_NUMERIC >= 80400
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_get_addresstype, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, ip_address, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if API_VERSION_NUMERIC >= 80400
+#define arginfo_ip2location_get_category arginfo_ip2location_get_addresstype
+#endif
+
+#if API_VERSION_NUMERIC >= 80600
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ip2location_get_district, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, ip_address, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if API_VERSION_NUMERIC >= 80600
+#define arginfo_ip2location_get_asn arginfo_ip2location_get_district
+#endif
+
+#if API_VERSION_NUMERIC >= 80600
+#define arginfo_ip2location_get_as arginfo_ip2location_get_district
+#endif
+
+
+ZEND_FUNCTION(ip2location_open);
+ZEND_FUNCTION(ip2location_open_mem);
+ZEND_FUNCTION(ip2location_get_country_short);
+ZEND_FUNCTION(ip2location_get_country_long);
+ZEND_FUNCTION(ip2location_get_region);
+ZEND_FUNCTION(ip2location_get_city);
+ZEND_FUNCTION(ip2location_get_isp);
+ZEND_FUNCTION(ip2location_get_latitude);
+ZEND_FUNCTION(ip2location_get_longitude);
+ZEND_FUNCTION(ip2location_get_domain);
+ZEND_FUNCTION(ip2location_get_zipcode);
+ZEND_FUNCTION(ip2location_get_timezone);
+ZEND_FUNCTION(ip2location_get_netspeed);
+ZEND_FUNCTION(ip2location_get_iddcode);
+ZEND_FUNCTION(ip2location_get_areacode);
+ZEND_FUNCTION(ip2location_get_weatherstationcode);
+ZEND_FUNCTION(ip2location_get_weatherstationname);
+ZEND_FUNCTION(ip2location_get_mcc);
+ZEND_FUNCTION(ip2location_get_mnc);
+ZEND_FUNCTION(ip2location_get_mobilebrand);
+ZEND_FUNCTION(ip2location_get_elevation);
+ZEND_FUNCTION(ip2location_get_usagetype);
+ZEND_FUNCTION(ip2location_get_all);
+ZEND_FUNCTION(ip2location_close);
+ZEND_FUNCTION(ip2location_delete_shm);
+#if API_VERSION_NUMERIC >= 80300
+ZEND_FUNCTION(ip2location_bin_version);
+#endif
+#if API_VERSION_NUMERIC >= 80400
+ZEND_FUNCTION(ip2location_get_addresstype);
+#endif
+#if API_VERSION_NUMERIC >= 80400
+ZEND_FUNCTION(ip2location_get_category);
+#endif
+#if API_VERSION_NUMERIC >= 80600
+ZEND_FUNCTION(ip2location_get_district);
+#endif
+#if API_VERSION_NUMERIC >= 80600
+ZEND_FUNCTION(ip2location_get_asn);
+#endif
+#if API_VERSION_NUMERIC >= 80600
+ZEND_FUNCTION(ip2location_get_as);
+#endif
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(ip2location_open, arginfo_ip2location_open)
+	ZEND_FE(ip2location_open_mem, arginfo_ip2location_open_mem)
+	ZEND_FE(ip2location_get_country_short, arginfo_ip2location_get_country_short)
+	ZEND_FE(ip2location_get_country_long, arginfo_ip2location_get_country_long)
+	ZEND_FE(ip2location_get_region, arginfo_ip2location_get_region)
+	ZEND_FE(ip2location_get_city, arginfo_ip2location_get_city)
+	ZEND_FE(ip2location_get_isp, arginfo_ip2location_get_isp)
+	ZEND_FE(ip2location_get_latitude, arginfo_ip2location_get_latitude)
+	ZEND_FE(ip2location_get_longitude, arginfo_ip2location_get_longitude)
+	ZEND_FE(ip2location_get_domain, arginfo_ip2location_get_domain)
+	ZEND_FE(ip2location_get_zipcode, arginfo_ip2location_get_zipcode)
+	ZEND_FE(ip2location_get_timezone, arginfo_ip2location_get_timezone)
+	ZEND_FE(ip2location_get_netspeed, arginfo_ip2location_get_netspeed)
+	ZEND_FE(ip2location_get_iddcode, arginfo_ip2location_get_iddcode)
+	ZEND_FE(ip2location_get_areacode, arginfo_ip2location_get_areacode)
+	ZEND_FE(ip2location_get_weatherstationcode, arginfo_ip2location_get_weatherstationcode)
+	ZEND_FE(ip2location_get_weatherstationname, arginfo_ip2location_get_weatherstationname)
+	ZEND_FE(ip2location_get_mcc, arginfo_ip2location_get_mcc)
+	ZEND_FE(ip2location_get_mnc, arginfo_ip2location_get_mnc)
+	ZEND_FE(ip2location_get_mobilebrand, arginfo_ip2location_get_mobilebrand)
+	ZEND_FE(ip2location_get_elevation, arginfo_ip2location_get_elevation)
+	ZEND_FE(ip2location_get_usagetype, arginfo_ip2location_get_usagetype)
+	ZEND_FE(ip2location_get_all, arginfo_ip2location_get_all)
+	ZEND_FE(ip2location_close, arginfo_ip2location_close)
+	ZEND_FE(ip2location_delete_shm, arginfo_ip2location_delete_shm)
+#if API_VERSION_NUMERIC >= 80300
+	ZEND_FE(ip2location_bin_version, arginfo_ip2location_bin_version)
+#endif
+#if API_VERSION_NUMERIC >= 80400
+	ZEND_FE(ip2location_get_addresstype, arginfo_ip2location_get_addresstype)
+#endif
+#if API_VERSION_NUMERIC >= 80400
+	ZEND_FE(ip2location_get_category, arginfo_ip2location_get_category)
+#endif
+#if API_VERSION_NUMERIC >= 80600
+	ZEND_FE(ip2location_get_district, arginfo_ip2location_get_district)
+#endif
+#if API_VERSION_NUMERIC >= 80600
+	ZEND_FE(ip2location_get_asn, arginfo_ip2location_get_asn)
+#endif
+#if API_VERSION_NUMERIC >= 80600
+	ZEND_FE(ip2location_get_as, arginfo_ip2location_get_as)
+#endif
+	ZEND_FE_END
+};

--- a/ip2location_legacy_arginfo.h
+++ b/ip2location_legacy_arginfo.h
@@ -1,0 +1,181 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: c57e18a606ee629525559e7f245e9643c54c59c5 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ip2location_open, 0, 0, 1)
+	ZEND_ARG_INFO(0, file_path)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ip2location_open_mem, 0, 0, 1)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ip2location_get_country_short, 0, 0, 1)
+	ZEND_ARG_INFO(0, ip_address)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ip2location_get_country_long arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_region arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_city arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_isp arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_latitude arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_longitude arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_domain arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_zipcode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_timezone arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_netspeed arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_iddcode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_areacode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_weatherstationcode arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_weatherstationname arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_mcc arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_mnc arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_mobilebrand arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_elevation arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_usagetype arginfo_ip2location_get_country_short
+
+#define arginfo_ip2location_get_all arginfo_ip2location_get_country_short
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ip2location_close, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ip2location_delete_shm arginfo_ip2location_close
+
+#if API_VERSION_NUMERIC >= 80300
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ip2location_bin_version, 0, 0, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if API_VERSION_NUMERIC >= 80400
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ip2location_get_addresstype, 0, 0, 1)
+	ZEND_ARG_INFO(0, ip_address)
+ZEND_END_ARG_INFO()
+#endif
+
+#if API_VERSION_NUMERIC >= 80400
+#define arginfo_ip2location_get_category arginfo_ip2location_get_addresstype
+#endif
+
+#if API_VERSION_NUMERIC >= 80600
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ip2location_get_district, 0, 0, 1)
+	ZEND_ARG_INFO(0, ip_address)
+ZEND_END_ARG_INFO()
+#endif
+
+#if API_VERSION_NUMERIC >= 80600
+#define arginfo_ip2location_get_asn arginfo_ip2location_get_district
+#endif
+
+#if API_VERSION_NUMERIC >= 80600
+#define arginfo_ip2location_get_as arginfo_ip2location_get_district
+#endif
+
+
+ZEND_FUNCTION(ip2location_open);
+ZEND_FUNCTION(ip2location_open_mem);
+ZEND_FUNCTION(ip2location_get_country_short);
+ZEND_FUNCTION(ip2location_get_country_long);
+ZEND_FUNCTION(ip2location_get_region);
+ZEND_FUNCTION(ip2location_get_city);
+ZEND_FUNCTION(ip2location_get_isp);
+ZEND_FUNCTION(ip2location_get_latitude);
+ZEND_FUNCTION(ip2location_get_longitude);
+ZEND_FUNCTION(ip2location_get_domain);
+ZEND_FUNCTION(ip2location_get_zipcode);
+ZEND_FUNCTION(ip2location_get_timezone);
+ZEND_FUNCTION(ip2location_get_netspeed);
+ZEND_FUNCTION(ip2location_get_iddcode);
+ZEND_FUNCTION(ip2location_get_areacode);
+ZEND_FUNCTION(ip2location_get_weatherstationcode);
+ZEND_FUNCTION(ip2location_get_weatherstationname);
+ZEND_FUNCTION(ip2location_get_mcc);
+ZEND_FUNCTION(ip2location_get_mnc);
+ZEND_FUNCTION(ip2location_get_mobilebrand);
+ZEND_FUNCTION(ip2location_get_elevation);
+ZEND_FUNCTION(ip2location_get_usagetype);
+ZEND_FUNCTION(ip2location_get_all);
+ZEND_FUNCTION(ip2location_close);
+ZEND_FUNCTION(ip2location_delete_shm);
+#if API_VERSION_NUMERIC >= 80300
+ZEND_FUNCTION(ip2location_bin_version);
+#endif
+#if API_VERSION_NUMERIC >= 80400
+ZEND_FUNCTION(ip2location_get_addresstype);
+#endif
+#if API_VERSION_NUMERIC >= 80400
+ZEND_FUNCTION(ip2location_get_category);
+#endif
+#if API_VERSION_NUMERIC >= 80600
+ZEND_FUNCTION(ip2location_get_district);
+#endif
+#if API_VERSION_NUMERIC >= 80600
+ZEND_FUNCTION(ip2location_get_asn);
+#endif
+#if API_VERSION_NUMERIC >= 80600
+ZEND_FUNCTION(ip2location_get_as);
+#endif
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(ip2location_open, arginfo_ip2location_open)
+	ZEND_FE(ip2location_open_mem, arginfo_ip2location_open_mem)
+	ZEND_FE(ip2location_get_country_short, arginfo_ip2location_get_country_short)
+	ZEND_FE(ip2location_get_country_long, arginfo_ip2location_get_country_long)
+	ZEND_FE(ip2location_get_region, arginfo_ip2location_get_region)
+	ZEND_FE(ip2location_get_city, arginfo_ip2location_get_city)
+	ZEND_FE(ip2location_get_isp, arginfo_ip2location_get_isp)
+	ZEND_FE(ip2location_get_latitude, arginfo_ip2location_get_latitude)
+	ZEND_FE(ip2location_get_longitude, arginfo_ip2location_get_longitude)
+	ZEND_FE(ip2location_get_domain, arginfo_ip2location_get_domain)
+	ZEND_FE(ip2location_get_zipcode, arginfo_ip2location_get_zipcode)
+	ZEND_FE(ip2location_get_timezone, arginfo_ip2location_get_timezone)
+	ZEND_FE(ip2location_get_netspeed, arginfo_ip2location_get_netspeed)
+	ZEND_FE(ip2location_get_iddcode, arginfo_ip2location_get_iddcode)
+	ZEND_FE(ip2location_get_areacode, arginfo_ip2location_get_areacode)
+	ZEND_FE(ip2location_get_weatherstationcode, arginfo_ip2location_get_weatherstationcode)
+	ZEND_FE(ip2location_get_weatherstationname, arginfo_ip2location_get_weatherstationname)
+	ZEND_FE(ip2location_get_mcc, arginfo_ip2location_get_mcc)
+	ZEND_FE(ip2location_get_mnc, arginfo_ip2location_get_mnc)
+	ZEND_FE(ip2location_get_mobilebrand, arginfo_ip2location_get_mobilebrand)
+	ZEND_FE(ip2location_get_elevation, arginfo_ip2location_get_elevation)
+	ZEND_FE(ip2location_get_usagetype, arginfo_ip2location_get_usagetype)
+	ZEND_FE(ip2location_get_all, arginfo_ip2location_get_all)
+	ZEND_FE(ip2location_close, arginfo_ip2location_close)
+	ZEND_FE(ip2location_delete_shm, arginfo_ip2location_delete_shm)
+#if API_VERSION_NUMERIC >= 80300
+	ZEND_FE(ip2location_bin_version, arginfo_ip2location_bin_version)
+#endif
+#if API_VERSION_NUMERIC >= 80400
+	ZEND_FE(ip2location_get_addresstype, arginfo_ip2location_get_addresstype)
+#endif
+#if API_VERSION_NUMERIC >= 80400
+	ZEND_FE(ip2location_get_category, arginfo_ip2location_get_category)
+#endif
+#if API_VERSION_NUMERIC >= 80600
+	ZEND_FE(ip2location_get_district, arginfo_ip2location_get_district)
+#endif
+#if API_VERSION_NUMERIC >= 80600
+	ZEND_FE(ip2location_get_asn, arginfo_ip2location_get_asn)
+#endif
+#if API_VERSION_NUMERIC >= 80600
+	ZEND_FE(ip2location_get_as, arginfo_ip2location_get_as)
+#endif
+	ZEND_FE_END
+};

--- a/pacakge.xml
+++ b/pacakge.xml
@@ -26,21 +26,24 @@ added address type and category.
  </notes>
  <contents>
   <dir name="/">
-   <file md5sum="0f65564cb7a1be32e4052b4541797989" name="tests/IP-COUNTRY-SAMPLE.BIN" role="test" />
-   <file md5sum="8d3ceada5844e0ecb63eb7a076363cea" name="tests/cache.phpt" role="test" />
-   <file md5sum="629a375fed6be8ab86bb7bd2e936be2a" name="tests/cachemethodtest.php" role="test" />
-   <file md5sum="0f6aa6a490cecea17043d3370e833b6f" name="tests/file.phpt" role="test" />
-   <file md5sum="f35030d136d93ab377cbc6e7cdba2711" name="tests/filemethodtest.php" role="test" />
-   <file md5sum="9a4bd6029f973d4519efce9509fa8fa7" name="tests/shm.phpt" role="test" />
-   <file md5sum="0f3ab62aa4e7d4b60497e16f8abeb668" name="tests/shmmethodtest.php" role="test" />
-   <file md5sum="5a3b05f178e045df6d4a9a8d4e7f6130" name="CREDITS" role="doc" />
-   <file md5sum="ff7ce8b3d73187538a6d5ed630d03ae3" name="IP2Loc_DBInterface.h" role="src" />
-   <file md5sum="2f7ba94e342799499bb8f6c495752984" name="LICENSE" role="doc" />
-   <file md5sum="89862fcd8c03ac0842ff9ebe812395ad" name="README.md" role="doc" />
-   <file md5sum="0c0fae61be67e7ac7c070205f8f6fe53" name="config.m4" role="src" />
-   <file md5sum="fd23d465c5de2141adb478f905d1c91b" name="config.w32" role="src" />
-   <file md5sum="99c4358668f25c05b897fad585c706bc" name="ip2location.c" role="src" />
-   <file md5sum="9cb8c64ae613952274f6327c808e753b" name="php_ip2location.h" role="src" />
+   <file name="tests/IP-COUNTRY-SAMPLE.BIN" role="test" />
+   <file name="tests/cache.phpt" role="test" />
+   <file name="tests/cachemethodtest.php" role="test" />
+   <file name="tests/file.phpt" role="test" />
+   <file name="tests/filemethodtest.php" role="test" />
+   <file name="tests/shm.phpt" role="test" />
+   <file name="tests/shmmethodtest.php" role="test" />
+   <file name="CREDITS" role="doc" />
+   <file name="IP2Loc_DBInterface.h" role="src" />
+   <file name="LICENSE" role="doc" />
+   <file name="README.md" role="doc" />
+   <file name="config.m4" role="src" />
+   <file name="config.w32" role="src" />
+   <file name="ip2location.c" role="src" />
+   <file name="ip2location_arginfo.h" role="src" />
+   <file name="ip2location_arginfo_legacy.h" role="src" />
+   <file name="ip2location.stub.php.h" role="src" />
+   <file name="php_ip2location.h" role="src" />
   </dir>
  </contents>
  <dependencies>

--- a/pacakge.xml
+++ b/pacakge.xml
@@ -49,7 +49,7 @@ added address type and category.
  <dependencies>
   <required>
    <php>
-    <min>5</min>
+    <min>5.4.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>

--- a/php_ip2location.h
+++ b/php_ip2location.h
@@ -37,46 +37,6 @@ PHP_MINFO_FUNCTION(ip2location);
 extern zend_module_entry ip2location_module_entry;
 #define phpext_ip2location_ptr &ip2location_module_entry
 
-
-
-PHP_FUNCTION(ip2location_open);
-PHP_FUNCTION(ip2location_open_mem);
-PHP_FUNCTION(ip2location_get_country_short);
-PHP_FUNCTION(ip2location_get_country_long);
-PHP_FUNCTION(ip2location_get_region);
-PHP_FUNCTION(ip2location_get_city);
-PHP_FUNCTION(ip2location_get_isp);
-PHP_FUNCTION(ip2location_get_latitude);
-PHP_FUNCTION(ip2location_get_longitude);
-PHP_FUNCTION(ip2location_get_domain);
-PHP_FUNCTION(ip2location_get_zipcode);
-PHP_FUNCTION(ip2location_get_timezone);
-PHP_FUNCTION(ip2location_get_netspeed);
-PHP_FUNCTION(ip2location_get_iddcode);
-PHP_FUNCTION(ip2location_get_areacode);
-PHP_FUNCTION(ip2location_get_weatherstationcode);
-PHP_FUNCTION(ip2location_get_weatherstationname);
-PHP_FUNCTION(ip2location_get_mcc);
-PHP_FUNCTION(ip2location_get_mnc);
-PHP_FUNCTION(ip2location_get_mobilebrand);
-PHP_FUNCTION(ip2location_get_elevation);
-PHP_FUNCTION(ip2location_get_usagetype);
-#if API_VERSION_NUMERIC >= 80400
-PHP_FUNCTION(ip2location_get_addresstype);
-PHP_FUNCTION(ip2location_get_category);
-#endif
-#if API_VERSION_NUMERIC >= 80600
-PHP_FUNCTION(ip2location_get_district);
-PHP_FUNCTION(ip2location_get_asn);
-PHP_FUNCTION(ip2location_get_as);
-#endif
-PHP_FUNCTION(ip2location_get_all);
-PHP_FUNCTION(ip2location_close);
-PHP_FUNCTION(ip2location_delete_shm);
-#if API_VERSION_NUMERIC >= 80300
-PHP_FUNCTION(ip2location_bin_version);
-#endif
-
 ZEND_BEGIN_MODULE_GLOBALS(ip2location)
         IP2Location *ip2location_ptr;
 ZEND_END_MODULE_GLOBALS(ip2location)


### PR DESCRIPTION
- add return type hinting
- generate arginfo from stub

This requires PHP 8+ to regenerate arginfo headers

This is a no change for older PHP versions

This should reduce dev work for new functions and give better information to extension users